### PR TITLE
Update: 댓글 WebSocket 구독을 페이지 레벨로 수정

### DIFF
--- a/components/layout/code-editor-layout.js
+++ b/components/layout/code-editor-layout.js
@@ -86,8 +86,6 @@ export default function CodeEditorLayout({
             roomId={roomId}
             snapshotId={snapshotId}
             snapshots={snapshots}
-            onSnapshotsUpdate={onSnapshotsUpdate}
-            roomUuid={roomUuid}
           />
         );
       case "voting":


### PR DESCRIPTION
# 🚀 개요

댓글 WebSocket 구독을 페이지 레벨로 수정하였습니다.

## 🔍 변경사항

- `question-panels`을 열지 않아도 페이지레벨에서 구독이 진행됩니다.
- 또힌, https://github.com/woori-codeshare/client-v2/pull/12 에서 미쳐 수정하지 못한 onSnapshotUpdate not define 에러를 해결하였습니다.